### PR TITLE
enable option CONFIG_GTK_OL (necessary for WPA3 support)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ CONFIG_IP_R_MONITOR = n #arp VOQ and high rate
 # user priority mapping rule : tos, dscp
 CONFIG_RTW_UP_MAPPING_RULE = tos
 CONFIG_RTW_MBO = n
+# necessary for WPA3 support
+CONFIG_GTK_OL = y
+
 ########################## Android ###########################
 # CONFIG_RTW_ANDROID - 0: no Android, 4/5/6/7/8/9/10/11 : Android version
 CONFIG_RTW_ANDROID = 0
@@ -1329,6 +1332,11 @@ EXTRA_CFLAGS += -DDM_ODM_SUPPORT_TYPE=0x04
 ifeq ($(CONFIG_RTW_MBO), y)
 EXTRA_CFLAGS += -DCONFIG_RTW_MBO -DCONFIG_RTW_80211K -DCONFIG_RTW_WNM -DCONFIG_RTW_BTM_ROAM
 EXTRA_CFLAGS += -DCONFIG_RTW_80211R
+endif
+
+# necessary for WPA3 support
+ifeq ($(CONFIG_GTK_OL), y)
+EXTRA_CFLAGS += -DCONFIG_GTK_OL
 endif
 
 ifeq ($(CONFIG_PLATFORM_I386_PC), y)


### PR DESCRIPTION
I copied this change from https://github.com/morrownr/88x2bu/commit/af47b1749fa970f46656cf3ac8ad451895ec13b9 and adapted for this driver version.  With this change this driver supports WPA3 operation when used in conjunction with a "top-of-tree" wpa_supplicant build (e.g., I tested this with the Debian "experimental" wpasupplicant (2:2.9.0+git20210909+a75fdcd-1), plus with my own local wpa_supplicant build).

E.g., using this wpa_supplicant configuration excerpt:

```
network={
    ssid="XXXX"
    scan_ssid=1
    sae_password="XXXX"
    proto=RSN
    key_mgmt=SAE
    ieee80211w=2
    group=CCMP
    pairwise=CCMP
}
```
...and verifying the authentication mode after association and connection:
```
root@dev2:~# wpa_cli status wlan0
Selected interface 'wlan0'
bssid=XXXX
freq=5745
ssid=XXXX
id=0
mode=station
wifi_generation=5
pairwise_cipher=CCMP
group_cipher=CCMP
key_mgmt=SAE
pmf=1
mgmt_group_cipher=BIP
sae_group=19
sae_h2e=0
sae_pk=0
wpa_state=COMPLETED
ip_address=XXXX
p2p_device_address=XXXX
address=XXXX
uuid=XXXX
ieee80211ac=1
root@dev2:~#
```


