### PR TITLE
Fix GCC misleading-indentation error

### DIFF
--- a/core/efuse/rtw_efuse.c
+++ b/core/efuse/rtw_efuse.c
@@ -940,11 +940,11 @@ void rtw_efuse_analyze(PADAPTER	padapter, u8 Type, u8 Fake)
 	for (i = 0; i < mapLen; i++) {
 		if (i % 16 == 0)
 			RTW_PRINT_SEL(RTW_DBGDUMP, "0x%03x: ", i);
-			_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
-				, pEfuseHal->fakeEfuseInitMap[i]
-				, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
-			);
-		}
+		_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
+			, pEfuseHal->fakeEfuseInitMap[i]
+			, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
+		);
+	}
 	_RTW_PRINT_SEL(RTW_DBGDUMP, "\n");
 
 out_free_buffer:


### PR DESCRIPTION
Since upgrading to Linux v5.18 in Nixpkgs, we've been seeing errors
from GCC about this confusing indentation.

Signed-off-by: Alyssa Ross <hi@alyssa.is>
