### PR TITLE
add Fedora kernel 6.1 to tested distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ be provided via PR or message in Issues.
 
 - Debian 11 (kernels 5.10 and 5.15)
 
-- Fedora (kernel 5.11)
+- Fedora (kernels 5.11 and 6.1)
 
 - Kali Linux (kernel 5.10)
 


### PR DESCRIPTION
A tested the driver on my system with a TP-Link AC600 Archer T2U Plus and it is working properly so I think we can update the README . My setup:
```
$ uname -r
6.1.9-200.fc37.x86_64

$ cat /etc/os-release
NAME="Fedora Linux"
VERSION="37 (Workstation Edition)"
...
```
