### PR TITLE
add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+modules.order
+Module.symvers
+*.cmd
+*.ko
+*.mod
+*.mod.c
+*.o


### PR DESCRIPTION
Added _.gitignore_ to ignore the build artifacts.

Before:
```
$ make 
make ARCH=x86_64 CROSS_COMPILE= -C /lib/modules/6.1.9-200.fc37.x86_64/build M=/home/gemesa/git-repos/8821au-20210708  modules
make[1]: Entering directory '/usr/src/kernels/6.1.9-200.fc37.x86_64'
  CC [M]  /home/gemesa/git-repos/8821au-20210708/core/rtw_cmd.o
  CC [M]  /home/gemesa/git-repos/8821au-20210708/core/rtw_security.o
...
$ git status
On branch main
Your branch is up to date with 'origin/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.8821au.ko.cmd
	.8821au.mod.cmd
	.8821au.mod.o.cmd
	.8821au.o.cmd
	.Module.symvers.cmd
	.modules.order.cmd
...
```
After:
```
$ make 
make ARCH=x86_64 CROSS_COMPILE= -C /lib/modules/6.1.9-200.fc37.x86_64/build M=/home/gemesa/git-repos/8821au-20210708  modules
make[1]: Entering directory '/usr/src/kernels/6.1.9-200.fc37.x86_64'
  CC [M]  /home/gemesa/git-repos/8821au-20210708/core/rtw_cmd.o
  CC [M]  /home/gemesa/git-repos/8821au-20210708/core/rtw_security.o
...
$ git status
On branch gitignore
Your branch is up to date with 'origin/gitignore'.

nothing to commit, working tree clean
```