### PR TITLE
add build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - docs/**
+      - LICENSE
+      - README.md
+
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - docs/**
+      - LICENSE
+      - README.md
+
+jobs:
+  ubuntu_22_04:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - cc: gcc-12
+            cxx: g++-12
+
+    name: Ubuntu 22.04 ${{ matrix.compiler.cc }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y ${{ matrix.compiler.cc }} ${{ matrix.compiler.cxx }} build-essential dkms git iw
+      - name: Build with ${{ matrix.compiler.cc }}
+        run: |
+          CPUS=$(nproc)
+          echo "::group::make clean"
+          make clean
+          echo "::endgroup::"
+          echo "::group::build"
+          make -j ${CPUS} CC=${{ matrix.compiler.cc }} CXX=${{ matrix.compiler.cxx }}
+          echo "::endgroup::"
+
+  ubuntu_20_04:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - cc:  gcc-11
+            cxx: g++-11
+          - cc:  gcc-10
+            cxx: g++-10
+          - cc:  gcc-9
+            cxx: g++-9
+
+    name: Ubuntu 20.04 ${{ matrix.compiler.cc }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y ${{ matrix.compiler.cc }} ${{ matrix.compiler.cxx }} build-essential dkms git iw
+      - name: Build with ${{ matrix.compiler.cc }}
+        run: |
+          CPUS=$(nproc)
+          echo "::group::make clean"
+          make clean
+          echo "::endgroup::"
+          echo "::group::build"
+          make -j ${CPUS} CC=${{ matrix.compiler.cc }} CXX=${{ matrix.compiler.cxx }}
+          echo "::endgroup::"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## 8821au ( 8821au.ko ) :rocket:
 
+[![CI](https://github.com/morrownr/8821au-20210708/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/morrownr/8821au-20210708/actions/workflows/ci.yml)
+
 ## Linux Driver for USB WiFi Adapters that are based on the RTL8811AU and RTL8821AU Chipsets
 
 - v5.12.5.2 (Realtek) (20210708) plus updates from the Linux community


### PR DESCRIPTION
Added a basic workflow which builds the repo on each PR and push to main with `gcc-9`, `gcc-10`, `gcc-11` and `gcc-12`. Doc files are ignored so they will not trigger the CI. See an example run [here](https://github.com/gemesa/8821au-20210708/actions/runs/4116538153). The badge added to README will look like this ('Coverity Scan' will be replaced with 'CI'):
![image](https://user-images.githubusercontent.com/59890178/217322819-09848054-59b4-48bb-86b4-f13e69ab0e87.png)
