### PR TITLE
rename build CI (CI --> Build CI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build CI
 
 on:
   # Allows you to run this workflow manually from the Actions tab

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## 8821au ( 8821au.ko ) :rocket:
 
-[![CI](https://github.com/morrownr/8821au-20210708/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/morrownr/8821au-20210708/actions/workflows/ci.yml)
+[![Build CI](https://github.com/morrownr/8821au-20210708/actions/workflows/build.yml/badge.svg?event=push)](https://github.com/morrownr/8821au-20210708/actions/workflows/build.yml)
 
 ## Linux Driver for USB WiFi Adapters that are based on the RTL8811AU and RTL8821AU Chipsets
 


### PR DESCRIPTION
Renamed CI to Build CI to make it obvious what is the workflow about. Is this enough for you or should I extend it with more information?