### PR TITLE
update build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - cc: gcc-12
+          - cc:  gcc-12
             cxx: g++-12
+          - cc:  gcc-11
+            cxx: g++-11
+          - cc:  gcc-10
+            cxx: g++-10
 
     name: Ubuntu 22.04 ${{ matrix.compiler.cc }}
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ confirm that this is the correct driver for your adapter.
 
 ### Tested Compilers
 
-- gcc 10, 11 and 12
+- gcc 9, 10, 11 and 12
 
 ### Tested Linux Distributions
 


### PR DESCRIPTION
Removed `gcc-9` from the build CI so it is synchronized with the README:

```
...

Tested Compilers

- gcc 10, 11 and 12
...
```

Also moved every step (`gcc-10`, `gcc-11`, `gcc-12`) to the ubuntu 22.04 job in the CI and removed the ubuntu 20.04 job so the CI config is more compact now.