### PR TITLE
ignore codespell.yml in build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
+      - .github/workflows/codespell.yml
       - .github/workflows/markdown-link.yml
       - .github/workflows/shellcheck.yml
       - docs/**
@@ -16,6 +17,7 @@ on:
   pull_request:
     branches: [ main ]
     paths-ignore:
+      - .github/workflows/codespell.yml
       - .github/workflows/markdown-link.yml
       - .github/workflows/shellcheck.yml
       - docs/**


### PR DESCRIPTION
The build CI should not be triggered when `codespell-yml` changes so I added it to the ignore paths.