### PR TITLE
update rtw_regd_init for kernel v6.4.4

### DIFF
--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -405,7 +405,7 @@ int rtw_regd_init(struct wiphy *wiphy)
 	wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 4))
 	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
 #endif
 


### PR DESCRIPTION
Kernel v6.4.4 backported the change from mainline v6.5 that removes `REGULATORY_IGNORE_STALE_KICKOFF`; this change updates `rtw_regd_init` in this driver accordingly.