### PR TITLE
Fix typo in DRV_NAME introduced in 7305e07

### DIFF
--- a/install-driver.sh
+++ b/install-driver.sh
@@ -30,7 +30,7 @@
 SCRIPT_NAME="install-driver.sh"
 SCRIPT_VERSION="20231001"
 
-DRV_NAME="rt8821au"
+DRV_NAME="rtl8821au"
 DRV_VERSION="5.12.5.2"
 DRV_DIR="$(pwd)"
 


### PR DESCRIPTION
Fix `DRV_NAME` typo as described in https://github.com/morrownr/8821au-20210708/issues/120