### PR TITLE
Revert "core: rtw_xmit: gate scan_state TX-block by _FW_UNDER_SURVEY to prevent permanent TX stall"

### DIFF
--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -6473,7 +6473,6 @@ bool rtw_xmit_ac_blocked(_adapter *adapter)
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
 	_adapter *iface;
-	struct mlme_priv *mlme;
 	struct mlme_ext_priv *mlmeext;
 	bool blocked = _FALSE;
 	int i;
@@ -6499,23 +6498,17 @@ bool rtw_xmit_ac_blocked(_adapter *adapter)
 
 	for (i = 0; i < dvobj->iface_nums; i++) {
 		iface = dvobj->padapters[i];
-		mlme = &iface->mlmepriv;
 		mlmeext = &iface->mlmeextpriv;
 
-		/* check scan state — gated by _FW_UNDER_SURVEY to avoid permanent
-		 * TX stall when rtw_scan_timeout_handler clears the upper flag but
-		 * mlmeext->scan_state stays stuck in SCAN_PROCESS (race when scan
-		 * never reaches SCAN_COMPLETE handler that resets scan_state). */
-		if (check_fwstate(mlme, _FW_UNDER_SURVEY)
-			&& mlmeext_scan_state(mlmeext) != SCAN_DISABLE
+		/* check scan state */
+		if (mlmeext_scan_state(mlmeext) != SCAN_DISABLE
 			&& mlmeext_scan_state(mlmeext) != SCAN_BACK_OP
 		) {
 			blocked = _TRUE;
 			goto exit;
 		}
 
-		if (check_fwstate(mlme, _FW_UNDER_SURVEY)
-			&& mlmeext_scan_state(mlmeext) == SCAN_BACK_OP
+		if (mlmeext_scan_state(mlmeext) == SCAN_BACK_OP
 			&& !mlmeext_chk_scan_backop_flags(mlmeext, SS_BACKOP_TX_RESUME)
 		) {
 			blocked = _TRUE;


### PR DESCRIPTION
Reverts morrownr/8821au-20210708#198